### PR TITLE
Prototype manifest referrer metadata store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ bin/*
 *.sublime-project
 *.sublime-workspace
 .idea/*
+.vscode/*

--- a/manifest/manifestlist/manifestlist.go
+++ b/manifest/manifestlist/manifestlist.go
@@ -26,7 +26,7 @@ var SchemaVersion = manifest.Versioned{
 // OCISchemaVersion provides a pre-initialized version structure for this
 // packages OCIschema version of the manifest.
 var OCISchemaVersion = manifest.Versioned{
-	SchemaVersion: 2,
+	SchemaVersion: 3,
 	MediaType:     v1.MediaTypeImageIndex,
 }
 
@@ -118,6 +118,9 @@ type ManifestList struct {
 
 	// Config references the image configuration as a blob.
 	Manifests []ManifestDescriptor `json:"manifests"`
+
+	// Config references the image configuration as a blob.
+	Config distribution.Descriptor `json:"config,omitempty"`
 }
 
 // References returns the distribution descriptors for the referenced image

--- a/manifests.go
+++ b/manifests.go
@@ -61,6 +61,9 @@ type ManifestService interface {
 	// Delete removes the manifest specified by the given digest. Deleting
 	// a manifest that doesn't exist will return ErrManifestNotFound
 	Delete(ctx context.Context, dgst digest.Digest) error
+
+	// ReferrerMetadata returns a collection of digests of referrer metadata objects, filtered by mediaType.
+	ReferrerMetadata(ctx context.Context, dgst digest.Digest, mediaType string) ([]digest.Digest, error)
 }
 
 // ManifestEnumerator enables iterating over manifests

--- a/registry/api/v2/descriptors.go
+++ b/registry/api/v2/descriptors.go
@@ -706,6 +706,71 @@ var routeDescriptors = []RouteDescriptor{
 	},
 
 	{
+		Name:        RouteNameManifestReferrerMetadata,
+		Path:        "/v2/{name:" + reference.NameRegexp.String() + "}/manifests/{reference:" + reference.TagRegexp.String() + "|" + digest.DigestRegexp.String() + "}/referrer-metadata",
+		Entity:      "Manifest referrer metadata",
+		Description: "Retrieve information about manifest referrer metadata.",
+		Methods: []MethodDescriptor{
+			{
+				Method:      "GET",
+				Description: "Fetch a list of manifest referrer metadata objects.",
+				Requests: []RequestDescriptor{
+					{
+						Name:        "ReferrerMetadata",
+						Description: "Return a list of all referrer metadata for the given manifest filtered by the given metadata media type.",
+						Headers: []ParameterDescriptor{
+							hostHeader,
+							authHeader,
+						},
+						PathParameters: []ParameterDescriptor{
+							nameParameterDescriptor,
+							referenceParameterDescriptor,
+						},
+						QueryParameters: []ParameterDescriptor{
+							{
+								Name:        "media-type",
+								Type:        "query",
+								Format:      "<mediaType>",
+								Description: `Media type of the requested referrer metadata.`,
+							},
+						},
+						Successes: []ResponseDescriptor{
+							{
+								StatusCode:  http.StatusOK,
+								Description: "A list of referrer metadata for the given manifest filtered by the given media type.",
+								Headers: []ParameterDescriptor{
+									{
+										Name:        "Content-Length",
+										Type:        "integer",
+										Description: "Length of the JSON response body.",
+										Format:      "<length>",
+									},
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json",
+									Format: `
+{
+	"digest": "<manifest digest>",
+	"tag": "<manifest tag>",
+	"@nextLink": "{opaqueUrl}",
+	"metadata": [
+			"<metadata digest>",
+			"<metadata digest>",
+			.
+			.
+	]
+}
+									`,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	{
 		Name:        RouteNameBlob,
 		Path:        "/v2/{name:" + reference.NameRegexp.String() + "}/blobs/{digest:" + digest.DigestRegexp.String() + "}",
 		Entity:      "Blob",

--- a/registry/api/v2/errors.go
+++ b/registry/api/v2/errors.go
@@ -70,6 +70,14 @@ var (
 		HTTPStatusCode: http.StatusNotFound,
 	})
 
+	// ErrorCodeManifestMetadataMediaTypeUnspecified returned when image manifest referrer metadata media type is not specified.
+	ErrorCodeManifestMetadataMediaTypeUnspecified = errcode.Register(errGroup, errcode.ErrorDescriptor{
+		Value:          "METADATA_MEDIA_TYPE_UNSPECIFIED",
+		Message:        "manifest referrer metadata media type is not specified",
+		Description:    `This error is returned when the manifest referrer metadata media type is not specified.`,
+		HTTPStatusCode: http.StatusBadRequest,
+	})
+
 	// ErrorCodeManifestInvalid returned when an image manifest is invalid,
 	// typically during a PUT operation. This error encompasses all errors
 	// encountered during manifest validation that aren't signature errors.
@@ -98,7 +106,7 @@ var (
 	ErrorCodeManifestBlobUnknown = errcode.Register(errGroup, errcode.ErrorDescriptor{
 		Value:   "MANIFEST_BLOB_UNKNOWN",
 		Message: "blob unknown to registry",
-		Description: `This error may be returned when a manifest blob is 
+		Description: `This error may be returned when a manifest blob is
 		unknown to the registry.`,
 		HTTPStatusCode: http.StatusBadRequest,
 	})

--- a/registry/api/v2/routes.go
+++ b/registry/api/v2/routes.go
@@ -5,13 +5,14 @@ import "github.com/gorilla/mux"
 // The following are definitions of the name under which all V2 routes are
 // registered. These symbols can be used to look up a route based on the name.
 const (
-	RouteNameBase            = "base"
-	RouteNameManifest        = "manifest"
-	RouteNameTags            = "tags"
-	RouteNameBlob            = "blob"
-	RouteNameBlobUpload      = "blob-upload"
-	RouteNameBlobUploadChunk = "blob-upload-chunk"
-	RouteNameCatalog         = "catalog"
+	RouteNameBase                     = "base"
+	RouteNameManifest                 = "manifest"
+	RouteNameManifestReferrerMetadata = "manifest-referrer-metadata"
+	RouteNameTags                     = "tags"
+	RouteNameBlob                     = "blob"
+	RouteNameBlobUpload               = "blob-upload"
+	RouteNameBlobUploadChunk          = "blob-upload-chunk"
+	RouteNameCatalog                  = "catalog"
 )
 
 // Router builds a gorilla router with named routes for the various API

--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -366,6 +366,10 @@ type manifests struct {
 	etags  map[string]string
 }
 
+func (ms *manifests) ReferrerMetadata(ctx context.Context, dgst digest.Digest, mediaType string) ([]digest.Digest, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 func (ms *manifests) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
 	ref, err := reference.WithDigest(ms.name, dgst)
 	if err != nil {

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -105,6 +105,7 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 		return http.HandlerFunc(apiBase)
 	})
 	app.register(v2.RouteNameManifest, manifestDispatcher)
+	app.register(v2.RouteNameManifestReferrerMetadata, manifestReferrerMetadataDispatcher)
 	app.register(v2.RouteNameCatalog, catalogDispatcher)
 	app.register(v2.RouteNameTags, tagsDispatcher)
 	app.register(v2.RouteNameBlob, blobDispatcher)

--- a/registry/handlers/manifestreferrermetadata.go
+++ b/registry/handlers/manifestreferrermetadata.go
@@ -1,0 +1,110 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/docker/distribution"
+	dcontext "github.com/docker/distribution/context"
+	"github.com/docker/distribution/registry/api/errcode"
+	v2 "github.com/docker/distribution/registry/api/v2"
+	"github.com/gorilla/handlers"
+	"github.com/opencontainers/go-digest"
+)
+
+// manifestReferrerMetadataDispatcher takes the request context and builds the
+// appropriate handler for handling manifest referrer metadata requests.
+func manifestReferrerMetadataDispatcher(ctx *Context, r *http.Request) http.Handler {
+	handler := &manifestReferrerMetadataHandler{
+		Context: ctx,
+	}
+	reference := getReference(ctx)
+	dgst, err := digest.Parse(reference)
+	if err != nil {
+		// We just have a tag
+		handler.Tag = reference
+	} else {
+		handler.Digest = dgst
+	}
+
+	mhandler := handlers.MethodHandler{
+		"GET": http.HandlerFunc(handler.All),
+	}
+
+	return mhandler
+}
+
+type manifestReferrerMetadataResponse struct {
+	Digest           digest.Digest   `json:"digest,omitempty"`
+	Tag              string          `json:"tag,omitempty"`
+	ReferrerMetadata []digest.Digest `json:"referrerMetadata"`
+	NextLink         string          `json:"nextLink"`
+}
+
+// manifestReferrerMetadataHandler handles http operations on image manifest referrer metadata.
+type manifestReferrerMetadataHandler struct {
+	*Context
+
+	// One of tag or digest gets set, depending on what is present in context.
+	Tag    string
+	Digest digest.Digest
+}
+
+// All fetches the list of manifest referrer metadata objects, filtered by media type specified in the request.
+func (mrmh *manifestReferrerMetadataHandler) All(w http.ResponseWriter, r *http.Request) {
+	dcontext.GetLogger(mrmh).Debug("All")
+
+	metadataMediaType := r.FormValue("media-type")
+	if metadataMediaType == "" {
+		mrmh.Errors = append(mrmh.Errors, v2.ErrorCodeManifestMetadataMediaTypeUnspecified)
+		return
+	}
+
+	if mrmh.Tag != "" {
+		tags := mrmh.Repository.Tags(mrmh)
+		desc, err := tags.Get(mrmh, mrmh.Tag)
+		if err != nil {
+			if _, ok := err.(distribution.ErrTagUnknown); ok {
+				mrmh.Errors = append(mrmh.Errors, v2.ErrorCodeManifestUnknown.WithDetail(err))
+			} else {
+				mrmh.Errors = append(mrmh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+			}
+			return
+		}
+		mrmh.Digest = desc.Digest
+	}
+
+	manifestService, err := mrmh.Repository.Manifests(mrmh)
+	if err != nil {
+		mrmh.Errors = append(mrmh.Errors, err)
+		return
+	}
+
+	referrerMetadata, err := manifestService.ReferrerMetadata(mrmh.Context, mrmh.Digest, metadataMediaType)
+	if err != nil {
+		if _, ok := err.(distribution.ErrManifestUnknownRevision); ok {
+			mrmh.Errors = append(mrmh.Errors, v2.ErrorCodeManifestUnknown.WithDetail(err))
+		} else {
+			mrmh.Errors = append(mrmh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+		}
+		return
+	}
+
+	if referrerMetadata == nil {
+		referrerMetadata = []digest.Digest{}
+	}
+
+	response := manifestReferrerMetadataResponse{ReferrerMetadata: referrerMetadata, NextLink: "not implemented"}
+	if mrmh.Tag != "" {
+		response.Tag = mrmh.Tag
+	} else {
+		response.Digest = mrmh.Digest
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	if err = enc.Encode(response); err != nil {
+		mrmh.Errors = append(mrmh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+		return
+	}
+}

--- a/registry/proxy/proxymanifeststore.go
+++ b/registry/proxy/proxymanifeststore.go
@@ -25,6 +25,10 @@ type proxyManifestStore struct {
 
 var _ distribution.ManifestService = &proxyManifestStore{}
 
+func (pms proxyManifestStore) ReferrerMetadata(ctx context.Context, dgst digest.Digest, mediaType string) ([]digest.Digest, error) {
+	return nil, distribution.ErrUnsupported
+}
+
 func (pms proxyManifestStore) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
 	exists, err := pms.localManifests.Exists(ctx, dgst)
 	if err != nil {

--- a/registry/proxy/proxymanifeststore_test.go
+++ b/registry/proxy/proxymanifeststore_test.go
@@ -61,6 +61,11 @@ func (sm statsManifest) Put(ctx context.Context, manifest distribution.Manifest,
 	return sm.manifests.Put(ctx, manifest)
 }
 
+func (sm statsManifest) ReferrerMetadata(ctx context.Context, dgst digest.Digest, mediaType string) ([]digest.Digest, error) {
+	sm.stats["referrermetadata"]++
+	return sm.ReferrerMetadata(ctx, dgst, mediaType)
+}
+
 type mockChallenger struct {
 	sync.Mutex
 	count int

--- a/registry/storage/ociindexhandler.go
+++ b/registry/storage/ociindexhandler.go
@@ -1,0 +1,116 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/distribution"
+	dcontext "github.com/docker/distribution/context"
+	"github.com/docker/distribution/manifest/manifestlist"
+	"github.com/opencontainers/go-digest"
+)
+
+// ociIndexHandler is a ManifestHandler that covers OCI index with config.
+type ociIndexHandler struct {
+	repository distribution.Repository
+	blobStore  distribution.BlobStore
+	ctx        context.Context
+	referrerMetadataStoreFunc
+}
+
+func (ms *ociIndexHandler) Unmarshal(ctx context.Context, dgst digest.Digest, content []byte) (distribution.Manifest, error) {
+	dcontext.GetLogger(ms.ctx).Debug("(*ociIndexHandler).Unmarshal")
+
+	m := &manifestlist.DeserializedManifestList{}
+	if err := m.UnmarshalJSON(content); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+func (ms *ociIndexHandler) Put(ctx context.Context, manifestList distribution.Manifest, skipDependencyVerification bool) (digest.Digest, error) {
+	dcontext.GetLogger(ms.ctx).Debug("(*ociIndexHandler).Put")
+
+	m, ok := manifestList.(*manifestlist.DeserializedManifestList)
+	if !ok {
+		return "", fmt.Errorf("wrong type put to ociIndexHandler: %T", manifestList)
+	}
+
+	if err := ms.verifyManifest(ms.ctx, *m, skipDependencyVerification); err != nil {
+		return "", err
+	}
+
+	mt, payload, err := m.Payload()
+	if err != nil {
+		return "", err
+	}
+
+	revision, err := ms.blobStore.Put(ctx, mt, payload)
+	if err != nil {
+		dcontext.GetLogger(ctx).Errorf("error putting payload into blobstore: %v", err)
+		return "", err
+	}
+
+	err = ms.linkReferrerMetadata(ctx, *m)
+	if err != nil {
+		dcontext.GetLogger(ctx).Errorf("error linking referrer metadata: %v", err)
+		return "", err
+	}
+
+	return revision.Digest, nil
+}
+
+// verifyManifest ensures that the manifest content is valid from the
+// perspective of the registry. As a policy, the registry only tries to
+// store valid content, leaving trust policies of that content up to
+// consumers.
+func (ms *ociIndexHandler) verifyManifest(ctx context.Context, mnfst manifestlist.DeserializedManifestList, skipDependencyVerification bool) error {
+	var errs distribution.ErrManifestVerification
+
+	if mnfst.SchemaVersion != 3 {
+		return fmt.Errorf("unrecognized manifest list schema version %d", mnfst.SchemaVersion)
+	}
+
+	if !skipDependencyVerification {
+		// This manifest service is different from the blob service
+		// returned by Blob. It uses a linked blob store to ensure that
+		// only manifests are accessible.
+
+		manifestService, err := ms.repository.Manifests(ctx)
+		if err != nil {
+			return err
+		}
+
+		for _, manifestDescriptor := range mnfst.References() {
+			exists, err := manifestService.Exists(ctx, manifestDescriptor.Digest)
+			if err != nil && err != distribution.ErrBlobUnknown {
+				errs = append(errs, err)
+			}
+			if err != nil || !exists {
+				// On error here, we always append unknown blob errors.
+				errs = append(errs, distribution.ErrManifestBlobUnknown{Digest: manifestDescriptor.Digest})
+			}
+		}
+
+		if configDigest := mnfst.Config.Digest; configDigest != "" {
+			blobStore := ms.repository.Blobs(ctx)
+			_, err = blobStore.Stat(ctx, configDigest)
+		}
+	}
+	if len(errs) != 0 {
+		return errs
+	}
+
+	return nil
+}
+
+func (ms *ociIndexHandler) linkReferrerMetadata(ctx context.Context, mnfst manifestlist.DeserializedManifestList) error {
+	// Link the manifest list config object as referrer metadata to each referenced manifest.
+	for _, manifestDescriptor := range mnfst.References() {
+		if err := ms.referrerMetadataStoreFunc(manifestDescriptor.Digest, mnfst.Config.MediaType).linkBlob(ctx, mnfst.Config); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This is a prototype implementation for manifest referrer metadata store to help illustrate workflows around storing and retrieving signatures. Further discussion on referrer metadata is available here: https://github.com/notaryproject/nv2/pull/12

In this PR:
- Added serialization support for OCI index schema version 3
- Added an OCI index storage handler. When an OCI index V3 is pushed, a link to its config object is added to the referrer metadata store of each referenced manifest. A discussion on whether the index itself should be linked to the manifests instead of the index config object is welcome: https://github.com/notaryproject/nv2/issues/13
- Added a new API to retrieve referrer metadata for a manifest. This can be used to retrieve manifest signatures by filtering on the appropriate media type: `/v2/hello-world/manifests/sha256:<sum>/referrer-metadata?media-type=application/vnd.cncf.notary.config.v2%2Bjwt`  

__TODO__:
- This PR defines its own type for an OCI Index V3 object. This type should instead be consumed from the OCI specs: https://github.com/opencontainers/artifacts/issues/25
