### PR TITLE
Add support for linked artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ bin/*
 *.sublime-project
 *.sublime-workspace
 .idea/*
+.vscode/*

--- a/errors.go
+++ b/errors.go
@@ -24,6 +24,15 @@ var ErrUnsupported = errors.New("operation unsupported")
 // manifest but the registry is configured to reject it
 var ErrSchemaV1Unsupported = errors.New("manifest schema v1 unsupported")
 
+// ErrArtifactTypeUnsupported is returned if the given artifact type is unsupported.
+type ErrArtifactTypeUnsupported struct {
+	ArtifactType string
+}
+
+func (err ErrArtifactTypeUnsupported) Error() string {
+	return fmt.Sprintf("unknown artifact type=%s", err.ArtifactType)
+}
+
 // ErrTagUnknown is returned if the given tag is not known by the tag service
 type ErrTagUnknown struct {
 	Tag string

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/docker/distribution
 
 go 1.12
 
+replace github.com/notaryproject/artifacts => ../artifacts
+
 require (
 	github.com/Azure/azure-sdk-for-go v16.2.1+incompatible
 	github.com/Azure/go-autorest v10.8.1+incompatible // indirect
@@ -29,7 +31,8 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f // indirect
 	github.com/ncw/swift v1.0.47
-	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/notaryproject/artifacts v0.0.0-00010101000000-000000000000
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/ncw/swift v1.0.47 h1:4DQRPj35Y41WogBxyhOXlrI37nzGlyEcsforeudyYPQ=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
-github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
-github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/manifest/artifact/artifact.go
+++ b/manifest/artifact/artifact.go
@@ -1,0 +1,137 @@
+package artifact
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest"
+	v2 "github.com/notaryproject/artifacts/specs-go/v2"
+	"github.com/opencontainers/go-digest"
+)
+
+// ArtifactVersion provides a pre-initialized version structure for this
+// packages Artifact version of the manifest.
+var ArtifactVersion = manifest.Versioned{
+	SchemaVersion: 2,
+	MediaType:     v2.MediaTypeArtifactManifest,
+}
+
+func init() {
+	artifactFunc := func(b []byte) (distribution.Manifest, distribution.Descriptor, error) {
+		d := new(DeserializedArtifact)
+		err := d.UnmarshalJSON(b)
+		if err != nil {
+			return nil, distribution.Descriptor{}, err
+		}
+
+		if d.inner.MediaType != "" && d.inner.MediaType != v2.MediaTypeArtifactManifest {
+			err = fmt.Errorf("if present, mediaType in artifact should be '%s' not '%s'",
+				v2.MediaTypeArtifactManifest, d.inner.MediaType)
+
+			return nil, distribution.Descriptor{}, err
+		}
+
+		dgst := digest.FromBytes(b)
+		return d, distribution.Descriptor{Digest: dgst, Size: int64(len(b)), MediaType: v2.MediaTypeArtifactManifest}, err
+	}
+	err := distribution.RegisterManifestSchema(v2.MediaTypeArtifactManifest, artifactFunc)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to register Artifact: %s", err))
+	}
+}
+
+// Artifact references manifests for various registry artifacts.
+type Artifact struct {
+	inner v2.Artifact
+}
+
+// ArtifactType returns the artifactType of this Artifact.
+func (a Artifact) ArtifactType() string {
+	return a.inner.ArtifactType
+}
+
+// References returns the distribution descriptors for the referenced blobs.
+func (a Artifact) References() []distribution.Descriptor {
+	blobs := make([]distribution.Descriptor, len(a.inner.Blobs))
+	for i := range a.inner.Blobs {
+		blobs[i] = distribution.Descriptor{
+			MediaType: a.inner.Blobs[i].MediaType,
+			Digest:    a.inner.Blobs[i].Digest,
+			Size:      a.inner.Blobs[i].Size,
+		}
+	}
+
+	if a.inner.Config != nil {
+		blobs = append(blobs, distribution.Descriptor{
+			MediaType: a.inner.Config.MediaType,
+			Digest:    a.inner.Config.Digest,
+			Size:      a.inner.Config.Size,
+		})
+	}
+
+	return blobs
+}
+
+// Manifests returns the distribution descriptors for the manifests that this artifact is linked to.
+func (a Artifact) Manifests() []distribution.Descriptor {
+	dependsOn := make([]distribution.Descriptor, len(a.inner.Manifests))
+	for i := range a.inner.Manifests {
+		dependsOn[i] = distribution.Descriptor{
+			MediaType: a.inner.Manifests[i].MediaType,
+			Digest:    a.inner.Manifests[i].Digest,
+			Size:      a.inner.Manifests[i].Size,
+		}
+	}
+
+	return dependsOn
+}
+
+// DeserializedArtifact wraps Artifact with a copy of the original JSON.
+type DeserializedArtifact struct {
+	Artifact
+
+	// canonical is the canonical byte representation of the Artifact.
+	canonical []byte
+}
+
+// UnmarshalJSON populates a new Artifact struct from JSON data.
+func (d *DeserializedArtifact) UnmarshalJSON(b []byte) error {
+	d.canonical = make([]byte, len(b))
+	// store manifest list in canonical
+	copy(d.canonical, b)
+
+	// Unmarshal canonical JSON into Artifact object
+	var artifact v2.Artifact
+	if err := json.Unmarshal(d.canonical, &artifact); err != nil {
+		return err
+	}
+
+	d.Artifact.inner = artifact
+
+	return nil
+}
+
+// MarshalJSON returns the contents of canonical. If canonical is empty,
+// marshals the inner contents.
+func (d *DeserializedArtifact) MarshalJSON() ([]byte, error) {
+	if len(d.canonical) > 0 {
+		return d.canonical, nil
+	}
+
+	return nil, errors.New("JSON representation not initialized in DeserializedArtifact")
+}
+
+// Payload returns the raw content of the Artifact. The contents can be
+// used to calculate the content identifier.
+func (d DeserializedArtifact) Payload() (string, []byte, error) {
+	var mediaType string
+	if d.inner.MediaType == "" {
+		mediaType = v2.MediaTypeArtifactManifest
+	} else {
+		mediaType = d.inner.MediaType
+	}
+
+	return mediaType, d.canonical, nil
+}

--- a/manifests.go
+++ b/manifests.go
@@ -61,6 +61,11 @@ type ManifestService interface {
 	// Delete removes the manifest specified by the given digest. Deleting
 	// a manifest that doesn't exist will return ErrManifestNotFound
 	Delete(ctx context.Context, dgst digest.Digest) error
+
+	// Referrers returns a collection of referrer manifests, filtered by referrerType.
+	// A referrer manifest describes an object that has a uni-directional link -->, of
+	// type referrerType, to the manifest described by the given dgst.
+	Referrers(ctx context.Context, dgst digest.Digest, referrerType string) ([]Manifest, error)
 }
 
 // ManifestEnumerator enables iterating over manifests

--- a/registry/api/v2/descriptors.go
+++ b/registry/api/v2/descriptors.go
@@ -706,6 +706,71 @@ var routeDescriptors = []RouteDescriptor{
 	},
 
 	{
+		Name:        RouteNameManifestLinkedArtifacts,
+		Path:        "/v2/_ext/oci-artifacts/v1/{name:" + reference.NameRegexp.String() + "}/manifests/{reference:" + reference.TagRegexp.String() + "|" + digest.DigestRegexp.String() + "}/links",
+		Entity:      "Linked artifacts",
+		Description: "Retrieve information about artifacts linked to this manifest.",
+		Methods: []MethodDescriptor{
+			{
+				Method:      "GET",
+				Description: "Fetch a list of artifacts linked to the manifest.",
+				Requests: []RequestDescriptor{
+					{
+						Name:        "Links",
+						Description: "Return a list of all artifacts linked to the given manifest filtered by the given artifact media type.",
+						Headers: []ParameterDescriptor{
+							hostHeader,
+							authHeader,
+						},
+						PathParameters: []ParameterDescriptor{
+							nameParameterDescriptor,
+							referenceParameterDescriptor,
+						},
+						QueryParameters: []ParameterDescriptor{
+							{
+								Name:        "artifact-type",
+								Type:        "query",
+								Format:      "<artifactType>",
+								Description: `Artifact type of the requested linked artifacts.`,
+							},
+						},
+						Successes: []ResponseDescriptor{
+							{
+								StatusCode:  http.StatusOK,
+								Description: "A list of artifact manifests for the given manifest filtered by the given artifact type.",
+								Headers: []ParameterDescriptor{
+									{
+										Name:        "Content-Length",
+										Type:        "integer",
+										Description: "Length of the JSON response body.",
+										Format:      "<length>",
+									},
+								},
+								Body: BodyDescriptor{
+									ContentType: "application/json",
+									Format: `
+{
+	"digest": "<manifest digest>",
+	"tag": "<manifest tag>",
+	"@nextLink": "{opaqueUrl}",
+	"links": [
+			{<artifact-manifest>},
+			{<artifact-manifest>},
+			.
+			.
+	]
+}
+									`,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+
+	{
 		Name:        RouteNameBlob,
 		Path:        "/v2/{name:" + reference.NameRegexp.String() + "}/blobs/{digest:" + digest.DigestRegexp.String() + "}",
 		Entity:      "Blob",

--- a/registry/api/v2/errors.go
+++ b/registry/api/v2/errors.go
@@ -70,6 +70,14 @@ var (
 		HTTPStatusCode: http.StatusNotFound,
 	})
 
+	// ErrorCodeArtifactTypeUnspecified is returned when the image manifest link artifact type is not specified.
+	ErrorCodeArtifactTypeUnspecified = errcode.Register(errGroup, errcode.ErrorDescriptor{
+		Value:          "ARTIFACT_TYPE_UNSPECIFIED",
+		Message:        "manifest link artifact type is not specified",
+		Description:    `This error is returned when the manifest link artifact type is not specified.`,
+		HTTPStatusCode: http.StatusBadRequest,
+	})
+
 	// ErrorCodeManifestInvalid returned when an image manifest is invalid,
 	// typically during a PUT operation. This error encompasses all errors
 	// encountered during manifest validation that aren't signature errors.
@@ -98,7 +106,7 @@ var (
 	ErrorCodeManifestBlobUnknown = errcode.Register(errGroup, errcode.ErrorDescriptor{
 		Value:   "MANIFEST_BLOB_UNKNOWN",
 		Message: "blob unknown to registry",
-		Description: `This error may be returned when a manifest blob is 
+		Description: `This error may be returned when a manifest blob is
 		unknown to the registry.`,
 		HTTPStatusCode: http.StatusBadRequest,
 	})

--- a/registry/api/v2/routes.go
+++ b/registry/api/v2/routes.go
@@ -5,13 +5,14 @@ import "github.com/gorilla/mux"
 // The following are definitions of the name under which all V2 routes are
 // registered. These symbols can be used to look up a route based on the name.
 const (
-	RouteNameBase            = "base"
-	RouteNameManifest        = "manifest"
-	RouteNameTags            = "tags"
-	RouteNameBlob            = "blob"
-	RouteNameBlobUpload      = "blob-upload"
-	RouteNameBlobUploadChunk = "blob-upload-chunk"
-	RouteNameCatalog         = "catalog"
+	RouteNameBase                    = "base"
+	RouteNameManifest                = "manifest"
+	RouteNameManifestLinkedArtifacts = "manifest-linked-artifacts"
+	RouteNameTags                    = "tags"
+	RouteNameBlob                    = "blob"
+	RouteNameBlobUpload              = "blob-upload"
+	RouteNameBlobUploadChunk         = "blob-upload-chunk"
+	RouteNameCatalog                 = "catalog"
 )
 
 // Router builds a gorilla router with named routes for the various API

--- a/registry/client/repository.go
+++ b/registry/client/repository.go
@@ -366,6 +366,10 @@ type manifests struct {
 	etags  map[string]string
 }
 
+func (ms *manifests) Referrers(_ context.Context, _ digest.Digest, _ string) ([]distribution.Manifest, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 func (ms *manifests) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
 	ref, err := reference.WithDigest(ms.name, dgst)
 	if err != nil {

--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -105,6 +105,7 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 		return http.HandlerFunc(apiBase)
 	})
 	app.register(v2.RouteNameManifest, manifestDispatcher)
+	app.register(v2.RouteNameManifestLinkedArtifacts, referrersDispatcher)
 	app.register(v2.RouteNameCatalog, catalogDispatcher)
 	app.register(v2.RouteNameTags, tagsDispatcher)
 	app.register(v2.RouteNameBlob, blobDispatcher)

--- a/registry/handlers/referrers.go
+++ b/registry/handlers/referrers.go
@@ -1,0 +1,110 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/docker/distribution"
+	dcontext "github.com/docker/distribution/context"
+	"github.com/docker/distribution/registry/api/errcode"
+	v2 "github.com/docker/distribution/registry/api/v2"
+	"github.com/gorilla/handlers"
+	"github.com/opencontainers/go-digest"
+)
+
+// referrersDispatcher takes the request context and builds the
+// appropriate handler for handling manifest referrer requests.
+func referrersDispatcher(ctx *Context, r *http.Request) http.Handler {
+	handler := &referrersHandler{
+		Context: ctx,
+	}
+	reference := getReference(ctx)
+	dgst, err := digest.Parse(reference)
+	if err != nil {
+		// We just have a tag
+		handler.Tag = reference
+	} else {
+		handler.Digest = dgst
+	}
+
+	mhandler := handlers.MethodHandler{
+		"GET": http.HandlerFunc(handler.Artifacts),
+	}
+
+	return mhandler
+}
+
+type referrersResponse struct {
+	Digest   digest.Digest           `json:"digest,omitempty"`
+	Tag      string                  `json:"tag,omitempty"`
+	Links    []distribution.Manifest `json:"links"`
+	NextLink string                  `json:"nextLink"`
+}
+
+// referrersHandler handles http operations on image manifest referrers.
+type referrersHandler struct {
+	*Context
+
+	// One of tag or digest gets set, depending on what is present in context.
+	Tag    string
+	Digest digest.Digest
+}
+
+// Artifacts fetches the list of manifest referrer artifacts, filtered by artifact type specified in the request.
+func (mrmh *referrersHandler) Artifacts(w http.ResponseWriter, r *http.Request) {
+	dcontext.GetLogger(mrmh).Debug("Artifacts")
+
+	artifactType := r.FormValue("artifact-type")
+	if artifactType == "" {
+		mrmh.Errors = append(mrmh.Errors, v2.ErrorCodeArtifactTypeUnspecified)
+		return
+	}
+
+	if mrmh.Tag != "" {
+		tags := mrmh.Repository.Tags(mrmh)
+		desc, err := tags.Get(mrmh, mrmh.Tag)
+		if err != nil {
+			if _, ok := err.(distribution.ErrTagUnknown); ok {
+				mrmh.Errors = append(mrmh.Errors, v2.ErrorCodeManifestUnknown.WithDetail(err))
+			} else {
+				mrmh.Errors = append(mrmh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+			}
+			return
+		}
+		mrmh.Digest = desc.Digest
+	}
+
+	manifestService, err := mrmh.Repository.Manifests(mrmh)
+	if err != nil {
+		mrmh.Errors = append(mrmh.Errors, err)
+		return
+	}
+
+	referrers, err := manifestService.Referrers(mrmh.Context, mrmh.Digest, artifactType)
+	if err != nil {
+		if _, ok := err.(distribution.ErrManifestUnknownRevision); ok {
+			mrmh.Errors = append(mrmh.Errors, v2.ErrorCodeManifestUnknown.WithDetail(err))
+		} else {
+			mrmh.Errors = append(mrmh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+		}
+		return
+	}
+
+	if referrers == nil {
+		referrers = []distribution.Manifest{}
+	}
+
+	response := referrersResponse{Links: referrers, NextLink: "not implemented"}
+	if mrmh.Tag != "" {
+		response.Tag = mrmh.Tag
+	} else {
+		response.Digest = mrmh.Digest
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	if err = enc.Encode(response); err != nil {
+		mrmh.Errors = append(mrmh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+		return
+	}
+}

--- a/registry/proxy/proxymanifeststore.go
+++ b/registry/proxy/proxymanifeststore.go
@@ -25,6 +25,10 @@ type proxyManifestStore struct {
 
 var _ distribution.ManifestService = &proxyManifestStore{}
 
+func (pms proxyManifestStore) Referrers(_ context.Context, _ digest.Digest, _ string) ([]distribution.Manifest, error) {
+	return nil, distribution.ErrUnsupported
+}
+
 func (pms proxyManifestStore) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
 	exists, err := pms.localManifests.Exists(ctx, dgst)
 	if err != nil {

--- a/registry/proxy/proxymanifeststore_test.go
+++ b/registry/proxy/proxymanifeststore_test.go
@@ -61,6 +61,11 @@ func (sm statsManifest) Put(ctx context.Context, manifest distribution.Manifest,
 	return sm.manifests.Put(ctx, manifest)
 }
 
+func (sm statsManifest) Referrers(ctx context.Context, dgst digest.Digest, referrerType string) ([]distribution.Manifest, error) {
+	sm.stats["referrers"]++
+	return sm.Referrers(ctx, dgst, referrerType)
+}
+
 type mockChallenger struct {
 	sync.Mutex
 	count int

--- a/registry/storage/ociartifacthandler.go
+++ b/registry/storage/ociartifacthandler.go
@@ -1,0 +1,127 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/distribution"
+	dcontext "github.com/docker/distribution/context"
+	"github.com/docker/distribution/manifest/artifact"
+	v2 "github.com/notaryproject/artifacts/specs-go/v2"
+	"github.com/opencontainers/go-digest"
+)
+
+// ociArtifactHandler is a ManifestHandler that covers OCI Artifacts.
+type ociArtifactHandler struct {
+	repository distribution.Repository
+	blobStore  distribution.BlobStore
+	ctx        context.Context
+	referrersStoreFunc
+}
+
+func (ah *ociArtifactHandler) Unmarshal(ctx context.Context, dgst digest.Digest, content []byte) (distribution.Manifest, error) {
+	dcontext.GetLogger(ah.ctx).Debug("(*artifactHandler).Unmarshal")
+
+	da := &artifact.DeserializedArtifact{}
+	if err := da.UnmarshalJSON(content); err != nil {
+		return nil, err
+	}
+
+	return da, nil
+}
+
+func (ah *ociArtifactHandler) Put(ctx context.Context, artifactManfiest distribution.Manifest, skipDependencyVerification bool) (digest.Digest, error) {
+	dcontext.GetLogger(ah.ctx).Debug("(*artifactHandler).Put")
+
+	da, ok := artifactManfiest.(*artifact.DeserializedArtifact)
+	if !ok {
+		return "", fmt.Errorf("wrong type put to artifactHandler: %T", artifactManfiest)
+	}
+
+	if err := ah.verifyManifest(ah.ctx, *da, skipDependencyVerification); err != nil {
+		return "", err
+	}
+
+	mt, payload, err := da.Payload()
+	if err != nil {
+		return "", err
+	}
+
+	revision, err := ah.blobStore.Put(ctx, mt, payload)
+	if err != nil {
+		dcontext.GetLogger(ctx).Errorf("error putting payload into blobstore: %v", err)
+		return "", err
+	}
+
+	err = ah.linkManifests(ctx, *da, revision.Digest)
+	if err != nil {
+		dcontext.GetLogger(ctx).Errorf("error linking referrer metadata: %v", err)
+		return "", err
+	}
+
+	return revision.Digest, nil
+}
+
+// verifyManifest ensures that the manifest content is valid from the
+// perspective of the registry. As a policy, the registry only tries to
+// store valid content, leaving trust policies of that content up to
+// consumers.
+func (ah *ociArtifactHandler) verifyManifest(ctx context.Context, da artifact.DeserializedArtifact, skipDependencyVerification bool) error {
+	var errs distribution.ErrManifestVerification
+
+	if !skipDependencyVerification {
+
+		daArtifactType := da.ArtifactType()
+		if daArtifactType != v2.ArtifactTypeNotaryV2 {
+			return append(errs, distribution.ErrArtifactTypeUnsupported{ArtifactType: daArtifactType})
+		}
+
+		blobStore := ah.repository.Blobs(ctx)
+
+		// All references must exist.
+		for _, blobDesc := range da.References() {
+			desc, err := blobStore.Stat(ctx, blobDesc.Digest)
+			if err != nil && err != distribution.ErrBlobUnknown {
+				errs = append(errs, err)
+			}
+			if err != nil || desc.Digest == "" {
+				// On error here, we always append unknown blob errors.
+				errs = append(errs, distribution.ErrManifestBlobUnknown{Digest: blobDesc.Digest})
+			}
+		}
+
+		manifestService, err := ah.repository.Manifests(ctx)
+		if err != nil {
+			return err
+		}
+
+		// All manifests to link to must exist.
+		for _, manifestDesc := range da.Manifests() {
+			exists, err := manifestService.Exists(ctx, manifestDesc.Digest)
+			if err != nil {
+				errs = append(errs, err)
+			} else {
+				if !exists {
+					errs = append(errs, distribution.ErrManifestUnknownRevision{Revision: manifestDesc.Digest})
+				}
+			}
+		}
+	}
+
+	if len(errs) != 0 {
+		return errs
+	}
+
+	return nil
+}
+
+func (ah *ociArtifactHandler) linkManifests(ctx context.Context, da artifact.DeserializedArtifact, revision digest.Digest) error {
+	daArtifactType := da.ArtifactType()
+	// Link the artifact as referrer metadata to each dependsOn manifest.
+	for _, manifestDesc := range da.Manifests() {
+		if err := ah.referrersStoreFunc(manifestDesc.Digest, daArtifactType).linkBlob(ctx, distribution.Descriptor{Digest: revision}); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -74,6 +74,8 @@ const (
 // 	manifestRevisionsPathSpec:      <root>/v2/repositories/<name>/_manifests/revisions/
 // 	manifestRevisionPathSpec:      <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/
 // 	manifestRevisionLinkPathSpec:  <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/link
+//  referrersPathSpec:             <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/ref/<referrerType>
+//  referrerRevisionLinkPathSpec:  <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/ref/<referrerType>/<algorithm>/<hex digest>/link
 //
 //	Tags:
 //
@@ -193,6 +195,25 @@ func pathFor(spec pathSpec) (string, error) {
 		}
 
 		return path.Join(root, path.Join(components...)), nil
+	case referrersPathSpec:
+		revisionPrefix, err := pathFor(manifestRevisionPathSpec{name: v.name, revision: v.referredRevision})
+		if err != nil {
+			return "", err
+		}
+
+		return path.Join(revisionPrefix, "ref", v.referrerType), nil
+	case referrerRevisionLinkPathSpec:
+		metadataPrefix, err := pathFor(referrersPathSpec{name: v.name, referredRevision: v.referredRevision, referrerType: v.referrerType})
+		if err != nil {
+			return "", err
+		}
+
+		metadataSuffix, err := digestPathComponents(v.referrerRevision, false)
+		if err != nil {
+			return "", err
+		}
+
+		return path.Join(append(append([]string{metadataPrefix}, metadataSuffix...), "link")...), nil
 	case layerLinkPathSpec:
 		components, err := digestPathComponents(v.digest, false)
 		if err != nil {
@@ -318,6 +339,27 @@ type manifestTagIndexPathSpec struct {
 }
 
 func (manifestTagIndexPathSpec) pathSpec() {}
+
+// referrersPathSpec describes the directory path for
+// manifest referrers of type referrerType.
+type referrersPathSpec struct {
+	name             string
+	referredRevision digest.Digest
+	referrerType     string
+}
+
+func (referrersPathSpec) pathSpec() {}
+
+// referrerRevisionLinkPathSpec describes the path components required to look
+// up the referrer revision link of a (referred) manifest revision.
+type referrerRevisionLinkPathSpec struct {
+	name             string
+	referredRevision digest.Digest
+	referrerType     string
+	referrerRevision digest.Digest
+}
+
+func (referrerRevisionLinkPathSpec) pathSpec() {}
 
 // manifestTagIndexEntryPathSpec contains the entries of the index by revision.
 type manifestTagIndexEntryPathSpec struct {

--- a/vendor/github.com/aviral26/artifacts/LICENSE
+++ b/vendor/github.com/aviral26/artifacts/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/aviral26/artifacts/specs-go/v2/artifact.go
+++ b/vendor/github.com/aviral26/artifacts/specs-go/v2/artifact.go
@@ -1,0 +1,20 @@
+package v2
+
+// Artifact describes a registry artifact.
+// This structure provides `application/vnd.oci.artifact.manifest.v1+json` mediatype when marshalled to JSON.
+type Artifact struct {
+	// MediaType is the media type of the object this schema refers to.
+	MediaType string `json:"mediaType"`
+
+	// ArtifactType is the artifact type of the object this schema refers to.
+	ArtifactType string `json:"artifactType"`
+
+	// Config references the index configuration.
+	Config Descriptor `json:"config"`
+
+	// Blobs references the content, such as signatures etc.
+	Blobs []Descriptor `json:"blobs"`
+
+	// Manifests is a collection of manifests this artifact is linked to.
+	Manifests []Descriptor `json:"manifests"`
+}

--- a/vendor/github.com/aviral26/artifacts/specs-go/v2/artifacttype.go
+++ b/vendor/github.com/aviral26/artifacts/specs-go/v2/artifacttype.go
@@ -1,0 +1,6 @@
+package v2
+
+const (
+	// ArtifactTypeNotaryV2 specifies the artifact type for a notary V2 object.
+	ArtifactTypeNotaryV2 = "application/vnd.cncf.notary.v2"
+)

--- a/vendor/github.com/aviral26/artifacts/specs-go/v2/descriptor.go
+++ b/vendor/github.com/aviral26/artifacts/specs-go/v2/descriptor.go
@@ -1,0 +1,64 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import digest "github.com/opencontainers/go-digest"
+
+// Descriptor describes the disposition of targeted content.
+// This structure provides `application/vnd.oci.descriptor.v1+json` mediatype
+// when marshalled to JSON.
+type Descriptor struct {
+	// MediaType is the media type of the object this schema refers to.
+	MediaType string `json:"mediaType,omitempty"`
+
+	// Digest is the digest of the targeted content.
+	Digest digest.Digest `json:"digest"`
+
+	// Size specifies the size in bytes of the blob.
+	Size int64 `json:"size"`
+
+	// URLs specifies a list of URLs from which this object MAY be downloaded
+	URLs []string `json:"urls,omitempty"`
+
+	// Annotations contains arbitrary metadata relating to the targeted content.
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Platform describes the platform which the image in the manifest runs on.
+	//
+	// This should only be used when referring to a manifest.
+	Platform *Platform `json:"platform,omitempty"`
+}
+
+// Platform describes the platform which the image in the manifest runs on.
+type Platform struct {
+	// Architecture field specifies the CPU architecture, for example
+	// `amd64` or `ppc64`.
+	Architecture string `json:"architecture"`
+
+	// OS specifies the operating system, for example `linux` or `windows`.
+	OS string `json:"os"`
+
+	// OSVersion is an optional field specifying the operating system
+	// version, for example on Windows `10.0.14393.1066`.
+	OSVersion string `json:"os.version,omitempty"`
+
+	// OSFeatures is an optional field specifying an array of strings,
+	// each listing a required OS feature (for example on Windows `win32k`).
+	OSFeatures []string `json:"os.features,omitempty"`
+
+	// Variant is an optional field specifying a variant of the CPU, for
+	// example `v7` to specify ARMv7 when architecture is `arm`.
+	Variant string `json:"variant,omitempty"`
+}

--- a/vendor/github.com/aviral26/artifacts/specs-go/v2/index.go
+++ b/vendor/github.com/aviral26/artifacts/specs-go/v2/index.go
@@ -1,0 +1,31 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+// Index references manifests for various platforms.
+// This structure provides `application/vnd.oci.image.index.v2+json` mediatype when marshalled to JSON.
+type Index struct {
+	// MediaType is the media type of the object this schema refers to.
+	MediaType string `json:"mediaType,omitempty"`
+
+	// Config references the index configuration.
+	Config Descriptor `json:"config,omitempty"`
+
+	// Manifests references platform specific manifests.
+	Manifests []Descriptor `json:"manifests"`
+
+	// Annotations contains arbitrary metadata for the image index.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}

--- a/vendor/github.com/aviral26/artifacts/specs-go/v2/mediatype.go
+++ b/vendor/github.com/aviral26/artifacts/specs-go/v2/mediatype.go
@@ -1,0 +1,23 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+const (
+	// MediaTypeImageIndex specifies the media type for an image index.
+	MediaTypeImageIndex = "application/vnd.oci.image.index.v2+json"
+
+	// MediaTypeArtifact specifies the media type for an OCI artifact.
+	MediaTypeArtifact = "application/vnd.oci.artifact.manifest.v1+json"
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,6 +10,8 @@ github.com/Azure/go-autorest/autorest/azure
 github.com/Azure/go-autorest/autorest/date
 # github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d
 github.com/Shopify/logrus-bugsnag
+# github.com/aviral26/artifacts v0.0.0-20210226112717-56144013f039
+github.com/aviral26/artifacts/specs-go/v2
 # github.com/aws/aws-sdk-go v1.15.11
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/awserr


### PR DESCRIPTION
This is a prototype implementation to demonstrate the use of OCI Artifacts for storing, discovering and retrieving notary v2 signatures.

In this PR:

- add support for OCI artifacts (see https://github.com/opencontainers/artifacts/pull/31)
- implement a new API, `/v2/_ext/oci-artifacts/v1/<repo>/manifests/<digest>/links?artifact-type=xyz` to enable linked artifacts discovery
  - the extensions API proposal is here: https://github.com/opencontainers/distribution-spec/pull/111

An illustrative example for storing and retrieving image signatures as OCI artifacts can be found here: https://github.com/aviral26/nv2/blob/prototype-2/docs/distribution/prototype-example.md